### PR TITLE
chore: add devEngines.packageManager to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,12 @@
   "bugs": {
     "url": "https://github.com/akashic-contents/thiefBuster-nicomoba/issues"
   },
-  "homepage": "https://github.com/akashic-contents/thiefBuster-nicomoba#readme"
+  "homepage": "https://github.com/akashic-contents/thiefBuster-nicomoba#readme",
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.11.0",
+      "onFail": "error"
+    }
+  }
 }


### PR DESCRIPTION
This PR adds `devEngines.packageManager` to package.json to enforce npm version.